### PR TITLE
Add ability to postpone transitions

### DIFF
--- a/database/factories/PendingTransition.php
+++ b/database/factories/PendingTransition.php
@@ -1,0 +1,18 @@
+<?php
+
+use Asantibanez\LaravelEloquentStateMachines\Models\PendingTransition;
+use Carbon\Carbon;
+use Faker\Generator as Faker;
+
+$factory->define(PendingTransition::class, function (Faker $faker) {
+    return [
+        'field' => $faker->word,
+        'from' => $faker->word,
+        'to' => $faker->word,
+
+        'transition_at' => Carbon::tomorrow(),
+
+        'model_id' => $faker->randomDigitNotNull,
+        'model_type' => $faker->word,
+    ];
+});

--- a/database/migrations/create_pending_transitions_table.php.stub
+++ b/database/migrations/create_pending_transitions_table.php.stub
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreatePendingTransitionsTable extends Migration
+{
+    public function up()
+    {
+        Schema::create('pending_transitions', function (Blueprint $table) {
+            $table->id();
+            $table->morphs('model');
+            $table->string('field');
+            $table->string('from')->nullable();
+            $table->string('to')->nullable();
+            $table->dateTime('transition_at');
+            $table->dateTime('applied_at')->nullable();
+            $table->json('custom_properties')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down()
+    {
+        Schema::dropIfExists('pending_transitions');
+    }
+}

--- a/database/migrations/create_pending_transitions_table.php.stub
+++ b/database/migrations/create_pending_transitions_table.php.stub
@@ -10,13 +10,19 @@ class CreatePendingTransitionsTable extends Migration
     {
         Schema::create('pending_transitions', function (Blueprint $table) {
             $table->id();
+
             $table->morphs('model');
             $table->string('field');
+
             $table->string('from')->nullable();
             $table->string('to')->nullable();
+
+            $table->json('custom_properties')->nullable();
+            $table->nullableMorphs('responsible');
+
             $table->dateTime('transition_at');
             $table->dateTime('applied_at')->nullable();
-            $table->json('custom_properties')->nullable();
+
             $table->timestamps();
         });
     }

--- a/database/migrations/create_state_histories_table.php.stub
+++ b/database/migrations/create_state_histories_table.php.stub
@@ -15,12 +15,16 @@ class CreateStateHistoriesTable extends Migration
     {
         Schema::create('state_histories', function (Blueprint $table) {
             $table->id();
+
             $table->morphs('model');
             $table->string('field');
+
             $table->string('from')->nullable();
             $table->string('to')->nullable();
+
             $table->json('custom_properties')->nullable();
             $table->nullableMorphs('responsible');
+
             $table->timestamps();
         });
     }

--- a/src/Exceptions/InvalidStartingStateException.php
+++ b/src/Exceptions/InvalidStartingStateException.php
@@ -8,5 +8,10 @@ use Exception;
 
 class InvalidStartingStateException extends Exception
 {
-    //
+    public function __construct($expectedState, $actualState)
+    {
+        $message = "Expected: $expectedState. Actual: $actualState";
+
+        parent::__construct($message);
+    }
 }

--- a/src/Exceptions/InvalidStartingStateException.php
+++ b/src/Exceptions/InvalidStartingStateException.php
@@ -1,0 +1,12 @@
+<?php
+
+
+namespace Asantibanez\LaravelEloquentStateMachines\Exceptions;
+
+
+use Exception;
+
+class InvalidStartingStateException extends Exception
+{
+    //
+}

--- a/src/Jobs/PendingTransitionExecutor.php
+++ b/src/Jobs/PendingTransitionExecutor.php
@@ -27,7 +27,8 @@ class PendingTransitionExecutor implements ShouldQueue
         $field = $this->pendingTransition->field;
         $model = $this->pendingTransition->model;
         $to = $this->pendingTransition->to;
+        $customProperties = $this->pendingTransition->custom_properties;
 
-        $model->$field()->transitionTo($to);
+        $model->$field()->transitionTo($to, $customProperties);
     }
 }

--- a/src/Jobs/PendingTransitionExecutor.php
+++ b/src/Jobs/PendingTransitionExecutor.php
@@ -1,0 +1,33 @@
+<?php
+
+
+namespace Asantibanez\LaravelEloquentStateMachines\Jobs;
+
+
+use Asantibanez\LaravelEloquentStateMachines\Models\PendingTransition;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+
+class PendingTransitionExecutor implements ShouldQueue
+{
+    use InteractsWithQueue, Queueable, Dispatchable, SerializesModels;
+
+    public $pendingTransition;
+
+    public function __construct(PendingTransition $pendingTransition)
+    {
+        $this->pendingTransition = $pendingTransition;
+    }
+
+    public function handle()
+    {
+        $field = $this->pendingTransition->field;
+        $model = $this->pendingTransition->model;
+        $to = $this->pendingTransition->to;
+
+        $model->$field()->transitionTo($to);
+    }
+}

--- a/src/Jobs/PendingTransitionExecutor.php
+++ b/src/Jobs/PendingTransitionExecutor.php
@@ -35,7 +35,13 @@ class PendingTransitionExecutor implements ShouldQueue
         $customProperties = $this->pendingTransition->custom_properties;
 
         if ($model->$field()->isNot($from)) {
-            throw new InvalidStartingStateException();
+            $exception = new InvalidStartingStateException(
+                $expectedState = $from,
+                $actualState = $model->$field()->state()
+            );
+
+            $this->fail($exception);
+            return;
         }
 
         $model->$field()->transitionTo($to, $customProperties);

--- a/src/Jobs/PendingTransitionExecutor.php
+++ b/src/Jobs/PendingTransitionExecutor.php
@@ -23,9 +23,6 @@ class PendingTransitionExecutor implements ShouldQueue
         $this->pendingTransition = $pendingTransition;
     }
 
-    /**
-     * @throws InvalidStartingStateException
-     */
     public function handle()
     {
         $field = $this->pendingTransition->field;
@@ -33,6 +30,7 @@ class PendingTransitionExecutor implements ShouldQueue
         $from = $this->pendingTransition->from;
         $to = $this->pendingTransition->to;
         $customProperties = $this->pendingTransition->custom_properties;
+        $responsible = $this->pendingTransition->responsible;
 
         if ($model->$field()->isNot($from)) {
             $exception = new InvalidStartingStateException(
@@ -44,6 +42,6 @@ class PendingTransitionExecutor implements ShouldQueue
             return;
         }
 
-        $model->$field()->transitionTo($to, $customProperties);
+        $model->$field()->transitionTo($to, $customProperties, $responsible);
     }
 }

--- a/src/Jobs/PendingTransitionExecutor.php
+++ b/src/Jobs/PendingTransitionExecutor.php
@@ -4,6 +4,7 @@
 namespace Asantibanez\LaravelEloquentStateMachines\Jobs;
 
 
+use Asantibanez\LaravelEloquentStateMachines\Exceptions\InvalidStartingStateException;
 use Asantibanez\LaravelEloquentStateMachines\Models\PendingTransition;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
@@ -22,12 +23,20 @@ class PendingTransitionExecutor implements ShouldQueue
         $this->pendingTransition = $pendingTransition;
     }
 
+    /**
+     * @throws InvalidStartingStateException
+     */
     public function handle()
     {
         $field = $this->pendingTransition->field;
         $model = $this->pendingTransition->model;
+        $from = $this->pendingTransition->from;
         $to = $this->pendingTransition->to;
         $customProperties = $this->pendingTransition->custom_properties;
+
+        if ($model->$field()->isNot($from)) {
+            throw new InvalidStartingStateException();
+        }
 
         $model->$field()->transitionTo($to, $customProperties);
     }

--- a/src/Jobs/PendingTransitionsDispatcher.php
+++ b/src/Jobs/PendingTransitionsDispatcher.php
@@ -1,0 +1,31 @@
+<?php
+
+
+namespace Asantibanez\LaravelEloquentStateMachines\Jobs;
+
+
+use Asantibanez\LaravelEloquentStateMachines\Models\PendingTransition;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+
+class PendingTransitionsDispatcher implements ShouldQueue
+{
+    use InteractsWithQueue, Queueable, Dispatchable, SerializesModels;
+
+    public function handle()
+    {
+        PendingTransition::with(['model'])
+            ->notApplied()
+            ->onScheduleOrOverdue()
+            ->get()
+            ->each(function (PendingTransition $pendingTransition) {
+                PendingTransitionExecutor::dispatch($pendingTransition);
+
+                $pendingTransition->applied_at = now();
+                $pendingTransition->save();
+            });
+    }
+}

--- a/src/Models/PendingTransition.php
+++ b/src/Models/PendingTransition.php
@@ -41,6 +41,11 @@ class PendingTransition extends Model
         $query->whereNull('applied_at');
     }
 
+    public function scopeOnScheduleOrOverdue($query)
+    {
+        $query->where('transition_at', '<=', now());
+    }
+
     public function scopeForField($query, $field)
     {
         $query->where('field', $field);

--- a/src/Models/PendingTransition.php
+++ b/src/Models/PendingTransition.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Asantibanez\LaravelEloquentStateMachines\Models;
+
+use Carbon\Carbon;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Class PendingTransition
+ * @package Asantibanez\LaravelEloquentStateMachines\Models
+ * @property string $field
+ * @property string $from
+ * @property string $to
+ * @property Carbon $transition_at
+ * @property Carbon $applied_at
+ * @property string $custom_properties
+ * @property Model $model
+ */
+class PendingTransition extends Model
+{
+    protected $guarded = [];
+
+    protected $casts = [
+        'custom_properties' => 'array',
+    ];
+
+    protected $dates = [
+        'transition_at' => 'date',
+        'applied_at' => 'date',
+    ];
+
+    public function model()
+    {
+        return $this->morphTo();
+    }
+
+    public function scopeNotApplied($query)
+    {
+        $query->whereNull('applied_at');
+    }
+
+    public function scopeForField($query, $field)
+    {
+        $query->where('field', $field);
+    }
+}

--- a/src/Models/PendingTransition.php
+++ b/src/Models/PendingTransition.php
@@ -17,6 +17,9 @@ use Illuminate\Database\Eloquent\Model;
  * @property int $model_id
  * @property string $model_type
  * @property Model $model
+ * @property int $responsible_id
+ * @property string $responsible_type
+ * @property Model $responsible
  */
 class PendingTransition extends Model
 {
@@ -32,6 +35,11 @@ class PendingTransition extends Model
     ];
 
     public function model()
+    {
+        return $this->morphTo();
+    }
+
+    public function responsible()
     {
         return $this->morphTo();
     }

--- a/src/Models/PendingTransition.php
+++ b/src/Models/PendingTransition.php
@@ -14,6 +14,8 @@ use Illuminate\Database\Eloquent\Model;
  * @property Carbon $transition_at
  * @property Carbon $applied_at
  * @property string $custom_properties
+ * @property int $model_id
+ * @property string $model_type
  * @property Model $model
  */
 class PendingTransition extends Model

--- a/src/Models/StateHistory.php
+++ b/src/Models/StateHistory.php
@@ -2,6 +2,7 @@
 
 namespace Asantibanez\LaravelEloquentStateMachines\Models;
 
+use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Model;
 
 /**
@@ -11,6 +12,7 @@ use Illuminate\Database\Eloquent\Model;
  * @property string $from
  * @property string $to
  * @property string $custom_properties
+ * @property Carbon $created_at
  */
 class StateHistory extends Model
 {

--- a/src/Models/StateHistory.php
+++ b/src/Models/StateHistory.php
@@ -7,7 +7,7 @@ use Illuminate\Database\Eloquent\Model;
 /**
  * Class StateHistory
  * @package Asantibanez\LaravelEloquentStateMachines\Models
- * @property string $transition
+ * @property string $field
  * @property string $from
  * @property string $to
  * @property string $custom_properties

--- a/src/StateMachines/State.php
+++ b/src/StateMachines/State.php
@@ -3,6 +3,7 @@
 
 namespace Asantibanez\LaravelEloquentStateMachines\StateMachines;
 
+use Asantibanez\LaravelEloquentStateMachines\Models\PendingTransition;
 use Asantibanez\LaravelEloquentStateMachines\Models\StateHistory;
 use Carbon\Carbon;
 
@@ -36,6 +37,11 @@ class State
     public function is($state)
     {
         return $this->state === $state;
+    }
+
+    public function isNot($state)
+    {
+        return !$this->is($state);
     }
 
     public function was($state)
@@ -88,9 +94,9 @@ class State
         $this->stateMachine->transitionTo($from = $this->state, $to = $state, $customProperties);
     }
 
-    public function postponeTransitionTo($state, Carbon $when, $customProperties = [])
+    public function postponeTransitionTo($state, Carbon $when, $customProperties = []) : PendingTransition
     {
-        $this->stateMachine->postponeTransitionTo(
+        return $this->stateMachine->postponeTransitionTo(
             $from = $this->state,
             $to = $state,
             $when,

--- a/src/StateMachines/State.php
+++ b/src/StateMachines/State.php
@@ -4,6 +4,7 @@
 namespace Asantibanez\LaravelEloquentStateMachines\StateMachines;
 
 use Asantibanez\LaravelEloquentStateMachines\Models\StateHistory;
+use Carbon\Carbon;
 
 /**
  * Class State
@@ -72,9 +73,29 @@ class State
         return $this->stateMachine->canBe($from = $this->state, $to = $state);
     }
 
+    public function pendingTransitions()
+    {
+        return $this->stateMachine->pendingTransitions();
+    }
+
+    public function hasPendingTransitions()
+    {
+        return $this->stateMachine->hasPendingTransitions();
+    }
+
     public function transitionTo($state, $customProperties = [])
     {
         $this->stateMachine->transitionTo($from = $this->state, $to = $state, $customProperties);
+    }
+
+    public function postponeTransitionTo($state, Carbon $when, $customProperties = [])
+    {
+        $this->stateMachine->postponeTransitionTo(
+            $from = $this->state,
+            $to = $state,
+            $when,
+            $customProperties
+        );
     }
 
     public function latest() : ?StateHistory

--- a/src/StateMachines/State.php
+++ b/src/StateMachines/State.php
@@ -3,6 +3,7 @@
 
 namespace Asantibanez\LaravelEloquentStateMachines\StateMachines;
 
+use Asantibanez\LaravelEloquentStateMachines\Exceptions\TransitionNotAllowedException;
 use Asantibanez\LaravelEloquentStateMachines\Models\PendingTransition;
 use Asantibanez\LaravelEloquentStateMachines\Models\StateHistory;
 use Carbon\Carbon;
@@ -99,13 +100,22 @@ class State
         );
     }
 
-    public function postponeTransitionTo($state, Carbon $when, $customProperties = []) : PendingTransition
+    /**
+     * @param $state
+     * @param Carbon $when
+     * @param array $customProperties
+     * @param null $responsible
+     * @return null|PendingTransition
+     * @throws TransitionNotAllowedException
+     */
+    public function postponeTransitionTo($state, Carbon $when, $customProperties = [], $responsible = null) : ?PendingTransition
     {
         return $this->stateMachine->postponeTransitionTo(
             $from = $this->state,
             $to = $state,
             $when,
-            $customProperties
+            $customProperties,
+            $responsible
         );
     }
 

--- a/src/StateMachines/StateMachine.php
+++ b/src/StateMachines/StateMachine.php
@@ -5,6 +5,7 @@ namespace Asantibanez\LaravelEloquentStateMachines\StateMachines;
 
 
 use Asantibanez\LaravelEloquentStateMachines\Exceptions\TransitionNotAllowedException;
+use Asantibanez\LaravelEloquentStateMachines\Models\PendingTransition;
 use Asantibanez\LaravelEloquentStateMachines\Models\StateHistory;
 use Carbon\Carbon;
 use Illuminate\Contracts\Validation\Validator;
@@ -112,9 +113,16 @@ abstract class StateMachine
         $this->cancelAllPendingTransitions();
     }
 
-    public function postponeTransitionTo($from, $to, Carbon $when, $customProperties = [])
+    /**
+     * @param $from
+     * @param $to
+     * @param Carbon $when
+     * @param array $customProperties
+     * @return PendingTransition
+     */
+    public function postponeTransitionTo($from, $to, Carbon $when, $customProperties = []) : PendingTransition
     {
-        $this->model->recordPendingTransition($this->field, $from, $to, $when, $customProperties);
+        return $this->model->recordPendingTransition($this->field, $from, $to, $when, $customProperties);
     }
 
     public function cancelAllPendingTransitions()

--- a/src/StateMachines/StateMachine.php
+++ b/src/StateMachines/StateMachine.php
@@ -80,6 +80,17 @@ abstract class StateMachine
         return collect($availableTransitions)->contains($to);
     }
 
+    public function pendingTransitions()
+    {
+        return $this->model->pendingTransitions()
+            ->forField($this->field);
+    }
+
+    public function hasPendingTransitions()
+    {
+        return $this->model->pendingTransitions()->notApplied()->exists();
+    }
+
     /**
      * @param $from
      * @param $to
@@ -114,11 +125,16 @@ abstract class StateMachine
             });
     }
 
-    abstract public function recordHistory() : bool;
+    public function postponeTransitionTo($from, $to, Carbon $when, $customProperties = [])
+    {
+        $this->model->recordPendingTransition($this->field, $from, $to, $when, $customProperties);
+    }
 
     abstract public function transitions() : array;
 
     abstract public function defaultState() : ?string;
+
+    abstract public function recordHistory() : bool;
 
     public function validatorForTransition($from, $to, $model): ?Validator
     {

--- a/src/StateMachines/StateMachine.php
+++ b/src/StateMachines/StateMachine.php
@@ -82,13 +82,12 @@ abstract class StateMachine
 
     public function pendingTransitions()
     {
-        return $this->model->pendingTransitions()
-            ->forField($this->field);
+        return $this->model->pendingTransitions()->forField($this->field);
     }
 
     public function hasPendingTransitions()
     {
-        return $this->model->pendingTransitions()->notApplied()->exists();
+        return $this->pendingTransitions()->notApplied()->exists();
     }
 
     /**
@@ -134,7 +133,7 @@ abstract class StateMachine
 
     public function cancelAllPendingTransitions()
     {
-        $this->model->pendingTransitions()->delete();
+        $this->pendingTransitions()->delete();
     }
 
     abstract public function transitions() : array;

--- a/src/StateMachines/StateMachine.php
+++ b/src/StateMachines/StateMachine.php
@@ -132,16 +132,30 @@ abstract class StateMachine
      * @param $to
      * @param Carbon $when
      * @param array $customProperties
-     * @return PendingTransition
+     * @param null $responsible
+     * @return null|PendingTransition
      * @throws TransitionNotAllowedException
      */
-    public function postponeTransitionTo($from, $to, Carbon $when, $customProperties = []) : PendingTransition
+    public function postponeTransitionTo($from, $to, Carbon $when, $customProperties = [], $responsible = null) : ?PendingTransition
     {
+        if ($to === $this->currentState()) {
+            return null;
+        }
+
         if (!$this->canBe($from, $to)) {
             throw new TransitionNotAllowedException();
         }
 
-        return $this->model->recordPendingTransition($this->field, $from, $to, $when, $customProperties);
+        $responsible = $responsible ?? auth()->user();
+
+        return $this->model->recordPendingTransition(
+            $this->field,
+            $from,
+            $to,
+            $when,
+            $customProperties,
+            $responsible
+        );
     }
 
     public function cancelAllPendingTransitions()

--- a/src/StateMachines/StateMachine.php
+++ b/src/StateMachines/StateMachine.php
@@ -119,9 +119,14 @@ abstract class StateMachine
      * @param Carbon $when
      * @param array $customProperties
      * @return PendingTransition
+     * @throws TransitionNotAllowedException
      */
     public function postponeTransitionTo($from, $to, Carbon $when, $customProperties = []) : PendingTransition
     {
+        if (!$this->canBe($from, $to)) {
+            throw new TransitionNotAllowedException();
+        }
+
         return $this->model->recordPendingTransition($this->field, $from, $to, $when, $customProperties);
     }
 

--- a/src/StateMachines/StateMachine.php
+++ b/src/StateMachines/StateMachine.php
@@ -23,20 +23,19 @@ abstract class StateMachine
         $this->model = $model;
     }
 
+    public function history()
+    {
+        return $this->model->stateHistory()->forField($this->field);
+    }
+
     public function was($state)
     {
-        return $this->model->stateHistory()
-            ->forField($this->field)
-            ->to($state)
-            ->exists();
+        return $this->history()->to($state)->exists();
     }
 
     public function timesWas($state)
     {
-        return $this->model->stateHistory()
-            ->forField($this->field)
-            ->to($state)
-            ->count();
+        return $this->history()->to($state)->count();
     }
 
     public function whenWas($state) : ?Carbon
@@ -52,25 +51,12 @@ abstract class StateMachine
 
     public function snapshotWhen($state) : ?StateHistory
     {
-        return $this->model->stateHistory()
-            ->forField($this->field)
-            ->to($state)
-            ->latest('id')
-            ->first();
+        return $this->history()->to($state)->latest('id')->first();
     }
 
     public function snapshotsWhen($state) : Collection
     {
-        return $this->model->stateHistory()
-            ->forField($this->field)
-            ->to($state)
-            ->get();
-    }
-
-    public function history()
-    {
-        return $this->model->stateHistory()
-            ->forField($this->field);
+        return $this->history()->to($state)->get();
     }
 
     public function canBe($from, $to)

--- a/src/StateMachines/StateMachine.php
+++ b/src/StateMachines/StateMachine.php
@@ -123,11 +123,18 @@ abstract class StateMachine
             ->each(function ($callable) use ($from) {
                 $callable($from, $this->model);
             });
+
+        $this->cancelAllPendingTransitions();
     }
 
     public function postponeTransitionTo($from, $to, Carbon $when, $customProperties = [])
     {
         $this->model->recordPendingTransition($this->field, $from, $to, $when, $customProperties);
+    }
+
+    public function cancelAllPendingTransitions()
+    {
+        $this->model->pendingTransitions()->delete();
     }
 
     abstract public function transitions() : array;

--- a/src/Traits/HasStateMachines.php
+++ b/src/Traits/HasStateMachines.php
@@ -2,6 +2,7 @@
 
 namespace Asantibanez\LaravelEloquentStateMachines\Traits;
 
+use Asantibanez\LaravelEloquentStateMachines\Models\PendingTransition;
 use Asantibanez\LaravelEloquentStateMachines\Models\StateHistory;
 use Asantibanez\LaravelEloquentStateMachines\StateMachines\State;
 use Illuminate\Database\Eloquent\Model;
@@ -61,6 +62,11 @@ trait HasStateMachines
         return $this->morphMany(StateHistory::class, 'model');
     }
 
+    public function pendingTransitions()
+    {
+        return $this->morphMany(PendingTransition::class, 'model');
+    }
+
     public function recordState($field, $from, $to, $customProperties = [])
     {
         $this->stateHistory()->save(
@@ -69,6 +75,19 @@ trait HasStateMachines
                 'from' => $from,
                 'to' => $to,
                 'custom_properties' => $customProperties,
+            ])
+        );
+    }
+
+    public function recordPendingTransition($field, $from, $to, $when, $customProperties = [])
+    {
+        $this->pendingTransitions()->save(
+            PendingTransition::make([
+                'field' => $field,
+                'from' => $from,
+                'to' => $to,
+                'transition_at' => $when,
+                'custom_properties' => $customProperties
             ])
         );
     }

--- a/src/Traits/HasStateMachines.php
+++ b/src/Traits/HasStateMachines.php
@@ -79,9 +79,9 @@ trait HasStateMachines
         );
     }
 
-    public function recordPendingTransition($field, $from, $to, $when, $customProperties = [])
+    public function recordPendingTransition($field, $from, $to, $when, $customProperties = []) : PendingTransition
     {
-        $this->pendingTransitions()->save(
+        return $this->pendingTransitions()->save(
             PendingTransition::make([
                 'field' => $field,
                 'from' => $from,

--- a/src/Traits/HasStateMachines.php
+++ b/src/Traits/HasStateMachines.php
@@ -86,16 +86,20 @@ trait HasStateMachines
         $this->stateHistory()->save($stateHistory);
     }
 
-    public function recordPendingTransition($field, $from, $to, $when, $customProperties = []) : PendingTransition
+    public function recordPendingTransition($field, $from, $to, $when, $customProperties = [], $responsible = null) : PendingTransition
     {
-        return $this->pendingTransitions()->save(
-            PendingTransition::make([
-                'field' => $field,
-                'from' => $from,
-                'to' => $to,
-                'transition_at' => $when,
-                'custom_properties' => $customProperties
-            ])
-        );
+        $pendingTransition = PendingTransition::make([
+            'field' => $field,
+            'from' => $from,
+            'to' => $to,
+            'transition_at' => $when,
+            'custom_properties' => $customProperties
+        ]);
+
+        if ($responsible !== null) {
+            $pendingTransition->responsible()->associate($responsible);
+        }
+
+        return $this->pendingTransitions()->save($pendingTransition);
     }
 }

--- a/tests/Feature/HasStateMachinesTest.php
+++ b/tests/Feature/HasStateMachinesTest.php
@@ -14,6 +14,7 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\WithFaker;
 use Illuminate\Validation\ValidationException;
 use Queue;
+use Throwable;
 
 class HasStateMachinesTest extends TestCase
 {
@@ -105,7 +106,7 @@ class HasStateMachinesTest extends TestCase
         try {
             $salesOrder->status()->transitionTo('pending');
             $this->fail('Should have thrown exception');
-        } catch (\Throwable $throwable) {
+        } catch (Throwable $throwable) {
             //Assert
             $this->assertTrue($throwable instanceof TransitionNotAllowedException);
         }
@@ -127,7 +128,7 @@ class HasStateMachinesTest extends TestCase
         try {
             $salesOrder->fulfillment()->transitionTo('pending');
             $this->fail('Should have thrown exception');
-        } catch (\Throwable $throwable) {
+        } catch (Throwable $throwable) {
             // Assert
             $this->assertTrue($throwable instanceof ValidationException);
         }
@@ -289,5 +290,21 @@ class HasStateMachinesTest extends TestCase
 
         $this->assertFalse($salesOrder->status()->hasPendingTransitions());
         $this->assertTrue($salesOrder->fulfillment()->hasPendingTransitions());
+    }
+
+    /** @test */
+    public function should_throw_exception_for_invalid_state_on_postponed_transition()
+    {
+        //Arrange
+        $salesOrder = factory(SalesOrder::class)->create();
+
+        //Act
+        try {
+            $salesOrder->status()->postponeTransitionTo('invalid', Carbon::tomorrow());
+            $this->fail('Should have thrown exception');
+        } catch (Throwable $exception) {
+            //Assert
+            $this->assertTrue($exception instanceof TransitionNotAllowedException);
+        }
     }
 }

--- a/tests/Feature/HasStateMachinesTest.php
+++ b/tests/Feature/HasStateMachinesTest.php
@@ -335,15 +335,20 @@ class HasStateMachinesTest extends TestCase
         //Arrange
         $salesOrder = factory(SalesOrder::class)->create();
 
+        $salesManager = factory(SalesManager::class)->create();
+
         //Act
         $customProperties = [
             'comments' => $this->faker->sentence,
         ];
 
+        $responsible = $salesManager;
+
         $salesOrder->status()->postponeTransitionTo(
             'approved',
             Carbon::tomorrow()->startOfDay(),
-            $customProperties
+            $customProperties,
+            $responsible
         );
 
         //Assert
@@ -367,6 +372,8 @@ class HasStateMachinesTest extends TestCase
         $this->assertNull($pendingTransition->applied_at);
 
         $this->assertEquals($salesOrder->id, $pendingTransition->model->id);
+
+        $this->assertEquals($salesManager->id, $pendingTransition->responsible->id);
     }
 
     /** @test */

--- a/tests/Feature/HasStateMachinesTest.php
+++ b/tests/Feature/HasStateMachinesTest.php
@@ -259,4 +259,26 @@ class HasStateMachinesTest extends TestCase
 
         $this->assertEquals($salesOrder->id, $pendingTransition->model->id);
     }
+
+    /** @test */
+    public function should_cancel_all_pending_transitions_when_transitioning_to_next_state()
+    {
+        //Arrange
+        $salesOrder = factory(SalesOrder::class)->create();
+
+        factory(PendingTransition::class)->times(10)->create([
+            'model_id' => $salesOrder->id,
+            'model_type' => SalesOrder::class,
+        ]);
+
+        $this->assertTrue($salesOrder->status()->hasPendingTransitions());
+
+        //Act
+        $salesOrder->status()->transitionTo('approved');
+
+        //Assert
+        $salesOrder->refresh();
+
+        $this->assertFalse($salesOrder->status()->hasPendingTransitions());
+    }
 }

--- a/tests/Feature/HasStateMachinesTest.php
+++ b/tests/Feature/HasStateMachinesTest.php
@@ -344,7 +344,7 @@ class HasStateMachinesTest extends TestCase
 
         $responsible = $salesManager;
 
-        $salesOrder->status()->postponeTransitionTo(
+        $pendingTransition = $salesOrder->status()->postponeTransitionTo(
             'approved',
             Carbon::tomorrow()->startOfDay(),
             $customProperties,
@@ -352,6 +352,8 @@ class HasStateMachinesTest extends TestCase
         );
 
         //Assert
+        $this->assertNotNull($pendingTransition);
+
         $salesOrder->refresh();
 
         $this->assertTrue($salesOrder->status()->is('pending'));
@@ -374,6 +376,24 @@ class HasStateMachinesTest extends TestCase
         $this->assertEquals($salesOrder->id, $pendingTransition->model->id);
 
         $this->assertEquals($salesManager->id, $pendingTransition->responsible->id);
+    }
+
+    /** @test */
+    public function should_not_record_pending_transition_for_same_state()
+    {
+        //Arrange
+        $salesOrder = factory(SalesOrder::class)->create();
+
+        $this->assertTrue($salesOrder->status()->is('pending'));
+
+        //Act
+        $pendingTransition = $salesOrder->status()->postponeTransitionTo(
+            'pending',
+            Carbon::tomorrow()->startOfDay()
+        );
+
+        //Assert
+        $this->assertNull($pendingTransition);
     }
 
     /** @test */

--- a/tests/Feature/HasStateMachinesTest.php
+++ b/tests/Feature/HasStateMachinesTest.php
@@ -266,12 +266,20 @@ class HasStateMachinesTest extends TestCase
         //Arrange
         $salesOrder = factory(SalesOrder::class)->create();
 
-        factory(PendingTransition::class)->times(10)->create([
+        factory(PendingTransition::class)->times(5)->create([
+            'field' => 'status',
+            'model_id' => $salesOrder->id,
+            'model_type' => SalesOrder::class,
+        ]);
+
+        factory(PendingTransition::class)->times(5)->create([
+            'field' => 'fulfillment',
             'model_id' => $salesOrder->id,
             'model_type' => SalesOrder::class,
         ]);
 
         $this->assertTrue($salesOrder->status()->hasPendingTransitions());
+        $this->assertTrue($salesOrder->fulfillment()->hasPendingTransitions());
 
         //Act
         $salesOrder->status()->transitionTo('approved');
@@ -280,5 +288,6 @@ class HasStateMachinesTest extends TestCase
         $salesOrder->refresh();
 
         $this->assertFalse($salesOrder->status()->hasPendingTransitions());
+        $this->assertTrue($salesOrder->fulfillment()->hasPendingTransitions());
     }
 }

--- a/tests/Feature/PendingTransitionExecutorTest.php
+++ b/tests/Feature/PendingTransitionExecutorTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Asantibanez\LaravelEloquentStateMachines\Tests\Feature;
+
+use Asantibanez\LaravelEloquentStateMachines\Jobs\PendingTransitionExecutor;
+use Asantibanez\LaravelEloquentStateMachines\Tests\TestCase;
+use Asantibanez\LaravelEloquentStateMachines\Tests\TestModels\SalesOrder;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+
+class PendingTransitionExecutorTest extends TestCase
+{
+    use RefreshDatabase;
+    use WithFaker;
+
+    /** @test */
+    public function should_apply_pending_transition()
+    {
+        //Arrange
+        $salesOrder = factory(SalesOrder::class)->create();
+
+        $salesOrder->status()->postponeTransitionTo('approved', Carbon::now());
+
+        $this->assertTrue($salesOrder->status()->is('pending'));
+
+        $this->assertTrue($salesOrder->status()->hasPendingTransitions());
+
+        //Act
+        $pendingTransition = $salesOrder->status()->pendingTransitions()->first();
+
+        PendingTransitionExecutor::dispatch($pendingTransition);
+
+        //Assert
+        $salesOrder->refresh();
+
+        $this->assertTrue($salesOrder->status()->is('approved'));
+
+        $this->assertFalse($salesOrder->status()->hasPendingTransitions());
+    }
+}

--- a/tests/Feature/PendingTransitionExecutorTest.php
+++ b/tests/Feature/PendingTransitionExecutorTest.php
@@ -2,12 +2,14 @@
 
 namespace Asantibanez\LaravelEloquentStateMachines\Tests\Feature;
 
+use Asantibanez\LaravelEloquentStateMachines\Exceptions\InvalidStartingStateException;
 use Asantibanez\LaravelEloquentStateMachines\Jobs\PendingTransitionExecutor;
 use Asantibanez\LaravelEloquentStateMachines\Tests\TestCase;
 use Asantibanez\LaravelEloquentStateMachines\Tests\TestModels\SalesOrder;
 use Carbon\Carbon;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\WithFaker;
+use Throwable;
 
 class PendingTransitionExecutorTest extends TestCase
 {
@@ -37,5 +39,31 @@ class PendingTransitionExecutorTest extends TestCase
         $this->assertTrue($salesOrder->status()->is('approved'));
 
         $this->assertFalse($salesOrder->status()->hasPendingTransitions());
+    }
+
+    /** @test */
+    public function should_throw_exception_if_starting_transition_is_not_the_same_as_when_postponed()
+    {
+        //Arrange
+        $salesOrder = factory(SalesOrder::class)->create();
+
+        $salesOrder->status()->postponeTransitionTo('approved', Carbon::now());
+
+        //Manually update state
+        $salesOrder->update(['status' => 'processed']);
+        $this->assertTrue($salesOrder->status()->is('processed'));
+
+        $this->assertTrue($salesOrder->status()->hasPendingTransitions());
+
+        //Act
+        $pendingTransition = $salesOrder->status()->pendingTransitions()->first();
+
+        try {
+            PendingTransitionExecutor::dispatch($pendingTransition);
+            $this->fail('Should have thrown exception');
+        } catch (Throwable $exception) {
+            //Assert
+            $this->assertTrue($exception instanceof InvalidStartingStateException);
+        }
     }
 }

--- a/tests/Feature/PendingTransitionsDispatcherTest.php
+++ b/tests/Feature/PendingTransitionsDispatcherTest.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Asantibanez\LaravelEloquentStateMachines\Tests\Feature;
+
+use Asantibanez\LaravelEloquentStateMachines\Exceptions\TransitionNotAllowedException;
+use Asantibanez\LaravelEloquentStateMachines\Jobs\PendingTransitionExecutor;
+use Asantibanez\LaravelEloquentStateMachines\Jobs\PendingTransitionsDispatcher;
+use Asantibanez\LaravelEloquentStateMachines\Models\PendingTransition;
+use Asantibanez\LaravelEloquentStateMachines\Tests\TestJobs\StartSalesOrderFulfillmentJob;
+use Asantibanez\LaravelEloquentStateMachines\Tests\TestCase;
+use Asantibanez\LaravelEloquentStateMachines\Tests\TestModels\SalesOrder;
+use Asantibanez\LaravelEloquentStateMachines\Tests\TestStateMachines\SalesOrders\FulfillmentStateMachine;
+use Asantibanez\LaravelEloquentStateMachines\Tests\TestStateMachines\SalesOrders\StatusStateMachine;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Validation\ValidationException;
+use Queue;
+
+class PendingTransitionsDispatcherTest extends TestCase
+{
+    use RefreshDatabase;
+    use WithFaker;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Queue::fake();
+    }
+
+    /** @test */
+    public function should_dispatch_pending_transition()
+    {
+        //Arrange
+        $salesOrder = factory(SalesOrder::class)->create();
+
+        $pendingTransition =
+            $salesOrder->status()->postponeTransitionTo('approved', Carbon::now()->subSecond());
+
+        $this->assertTrue($salesOrder->status()->hasPendingTransitions());
+
+        //Act
+        PendingTransitionsDispatcher::dispatchNow();
+
+        //Assert
+        $salesOrder->refresh();
+
+        $this->assertFalse($salesOrder->status()->hasPendingTransitions());
+
+        Queue::assertPushed(PendingTransitionExecutor::class, function ($job) use ($pendingTransition) {
+            $this->assertEquals($pendingTransition->id, $job->pendingTransition->id);
+            return true;
+        });
+    }
+
+    /** @test */
+    public function should_not_dispatch_future_pending_transitions()
+    {
+        //Arrange
+        $salesOrder = factory(SalesOrder::class)->create();
+
+        $salesOrder->status()->postponeTransitionTo('approved', Carbon::tomorrow());
+
+        $this->assertTrue($salesOrder->status()->hasPendingTransitions());
+
+        //Act
+        PendingTransitionsDispatcher::dispatchNow();
+
+        //Assert
+        $salesOrder->refresh();
+
+        $this->assertTrue($salesOrder->status()->hasPendingTransitions());
+
+        Queue::assertNothingPushed();
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,6 +2,7 @@
 
 namespace Asantibanez\LaravelEloquentStateMachines\Tests;
 
+use CreatePendingTransitionsTable;
 use CreateSalesOrdersTable;
 use CreateStateHistoriesTable;
 use Javoscript\MacroableModels\MacroableModelsServiceProvider;
@@ -30,10 +31,12 @@ class TestCase extends BaseTestCase
     protected function getEnvironmentSetUp($app)
     {
         include_once __DIR__ . '/../database/migrations/create_state_histories_table.php.stub';
+        include_once __DIR__ . '/../database/migrations/create_pending_transitions_table.php.stub';
 
         include_once __DIR__ . '/database/migrations/create_sales_orders_table.php';
 
         (new CreateStateHistoriesTable())->up();
+        (new CreatePendingTransitionsTable())->up();
         (new CreateSalesOrdersTable())->up();
     }
 }


### PR DESCRIPTION
## Summary

This PR adds the ability to postpone transitions allowing a model to change its state after a specified date/time. The api is similar to `transitionTo` but in this case we use `postponeTransitionTo` passing an extra `$when` parameter.

```php
$salesOrder->status()->postponeTransitionTo('approved', $when = Carbon::tomorrow(), $customProperties);
```

This postponed transitions are stored in a new `PendingTransition` model. A new migration is also added.

### Checking Pending Transitions

If needed, one can check if there are pending transitions for a model state

```php
$salesOrder->status()->hasPendingTransitions(); // true / false
```

One can also cancel all pending transitions if needed

```php
$salesOrder->status()->cancelPendingTransitions();
```

### Running Pending Transitions

Pending Transitions will be run according to when they were scheduled to run. `transition_at` field in `PendingTransition` model provides this information. When ran, the `applied_at` field is updated with the current date/time. This field is also used to not run pending transitions again.

Pending Transitions can be run automatically by scheduling a the new `PendingTransitionsDispatcher` job to your apps kernel. According to your needs, it may be scheduled to run every minute, five, ten, etc.

```php
protected function schedule(Schedule $schedule)
{
        $schedule->job(PendingTransitionsDispatcher::class)->everyMinute();
}
```

This job checks all pending transitions and dispatches an executor job which will be responsible for applying the pending transition. The job will check if the starting state `$from` matches the actual state of the model's state machine before applying the transition. The transition will run as it would normally would, running custom validators and hooks if any.
