### PR TITLE
Added check for auto recording history when on creating model event

### DIFF
--- a/src/Traits/HasStateMachines.php
+++ b/src/Traits/HasStateMachines.php
@@ -33,11 +33,14 @@ trait HasStateMachines
         self::created(function (Model $model) {
             collect($model->stateMachines)
                 ->each(function ($_, $field) use ($model) {
-                    $stateMachine = $model->{$field}()->stateMachine();
-                    $defaultState = $stateMachine->defaultState();
-                    $currentState = $model->{$field};
+                    $currentState = $model->$field;
+                    $stateMachine = $model->$field()->stateMachine();
 
-                    if ($defaultState === null) {
+                    if ($currentState === null) {
+                        return;
+                    }
+
+                    if (!$stateMachine->recordHistory()) {
                         return;
                     }
 

--- a/tests/Feature/HasStateMachinesTest.php
+++ b/tests/Feature/HasStateMachinesTest.php
@@ -151,6 +151,46 @@ class HasStateMachinesTest extends TestCase
     }
 
     /** @test */
+    public function should_record_history_when_creating_model()
+    {
+        //Arrange
+        $dummySalesOrder = new SalesOrder();
+
+        $stateMachine = new StatusStateMachine('status', $dummySalesOrder);
+
+        $this->assertTrue($stateMachine->recordHistory());
+
+        //Act
+        $salesOrder = factory(SalesOrder::class)->create();
+
+        //Assert
+        $salesOrder->refresh();
+
+        $this->assertEquals(1, $salesOrder->status()->history()->count());
+    }
+
+    /** @test */
+    public function should_not_record_history_when_creating_model_if_record_history_turned_off()
+    {
+        //Arrange
+        $dummySalesOrder = new SalesOrder();
+
+        $stateMachine = new FulfillmentStateMachine('fulfillment', $dummySalesOrder);
+
+        $this->assertFalse($stateMachine->recordHistory());
+
+        //Act
+        $salesOrder = factory(SalesOrder::class)->create([
+            'fulfillment' => 'pending',
+        ]);
+
+        //Assert
+        $salesOrder->refresh();
+
+        $this->assertEquals(0, $salesOrder->fulfillment()->history()->count());
+    }
+
+    /** @test */
     public function can_record_history_with_custom_properties_when_transitioning_to_next_state()
     {
         //Arrange


### PR DESCRIPTION
## Summary 

This PR fixes auto-recording history on model creation for state machines that have `recordHistory()` turned off. Before, the initial state was saved in `StateHistory` without checking if the history was required in the state machine config.