### PR TITLE
Add responsible property to StateHistory model

### DIFF
--- a/database/migrations/create_state_histories_table.php.stub
+++ b/database/migrations/create_state_histories_table.php.stub
@@ -20,6 +20,7 @@ class CreateStateHistoriesTable extends Migration
             $table->string('from')->nullable();
             $table->string('to')->nullable();
             $table->json('custom_properties')->nullable();
+            $table->nullableMorphs('responsible');
             $table->timestamps();
         });
     }

--- a/src/Models/StateHistory.php
+++ b/src/Models/StateHistory.php
@@ -3,6 +3,7 @@
 namespace Asantibanez\LaravelEloquentStateMachines\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Foundation\Auth\User;
 
 /**
  * Class StateHistory
@@ -11,6 +12,9 @@ use Illuminate\Database\Eloquent\Model;
  * @property string $from
  * @property string $to
  * @property string $custom_properties
+ * @property int $responsible_id
+ * @property string $responsible_type
+ * @property mixed $responsible
  */
 class StateHistory extends Model
 {
@@ -23,6 +27,11 @@ class StateHistory extends Model
     public function getCustomProperty($key)
     {
         return data_get($this->custom_properties, $key, null);
+    }
+
+    public function responsible()
+    {
+        return $this->morphTo();
     }
 
     public function allCustomProperties()

--- a/src/StateMachines/State.php
+++ b/src/StateMachines/State.php
@@ -72,9 +72,14 @@ class State
         return $this->stateMachine->canBe($from = $this->state, $to = $state);
     }
 
-    public function transitionTo($state, $customProperties = [])
+    public function transitionTo($state, $customProperties = [], $responsible = null)
     {
-        $this->stateMachine->transitionTo($from = $this->state, $to = $state, $customProperties);
+        $this->stateMachine->transitionTo(
+            $from = $this->state,
+            $to = $state,
+            $customProperties,
+            $responsible
+        );
     }
 
     public function latest() : ?StateHistory
@@ -85,6 +90,11 @@ class State
     public function getCustomProperty($key)
     {
         return optional($this->latest())->getCustomProperty($key);
+    }
+
+    public function responsible()
+    {
+        return optional($this->latest())->responsible;
     }
 
     public function allCustomProperties()

--- a/src/StateMachines/StateMachine.php
+++ b/src/StateMachines/StateMachine.php
@@ -84,10 +84,11 @@ abstract class StateMachine
      * @param $from
      * @param $to
      * @param array $customProperties
+     * @param null|mixed $responsible
      * @throws TransitionNotAllowedException
      * @throws ValidationException
      */
-    public function transitionTo($from, $to, $customProperties = [])
+    public function transitionTo($from, $to, $customProperties = [], $responsible = null)
     {
         if (!$this->canBe($from, $to)) {
             throw new TransitionNotAllowedException();
@@ -103,7 +104,9 @@ abstract class StateMachine
         $this->model->save();
 
         if ($this->recordHistory()) {
-            $this->model->recordState($field, $from, $to, $customProperties);
+            $responsible = $responsible ?? auth()->user();
+
+            $this->model->recordState($field, $from, $to, $customProperties, $responsible);
         }
 
         $transitionHooks = $this->transitionHooks()[$to] ?? [];

--- a/src/Traits/HasStateMachines.php
+++ b/src/Traits/HasStateMachines.php
@@ -64,15 +64,19 @@ trait HasStateMachines
         return $this->morphMany(StateHistory::class, 'model');
     }
 
-    public function recordState($field, $from, $to, $customProperties = [])
+    public function recordState($field, $from, $to, $customProperties = [], $responsible = null)
     {
-        $this->stateHistory()->save(
-            StateHistory::make([
-                'field' => $field,
-                'from' => $from,
-                'to' => $to,
-                'custom_properties' => $customProperties,
-            ])
-        );
+        $stateHistory = StateHistory::make([
+            'field' => $field,
+            'from' => $from,
+            'to' => $to,
+            'custom_properties' => $customProperties,
+        ]);
+
+        if ($responsible !== null) {
+            $stateHistory->responsible()->associate($responsible);
+        }
+
+        $this->stateHistory()->save($stateHistory);
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,6 +2,7 @@
 
 namespace Asantibanez\LaravelEloquentStateMachines\Tests;
 
+use CreateSalesManagersTable;
 use CreateSalesOrdersTable;
 use CreateStateHistoriesTable;
 use Javoscript\MacroableModels\MacroableModelsServiceProvider;
@@ -32,8 +33,10 @@ class TestCase extends BaseTestCase
         include_once __DIR__ . '/../database/migrations/create_state_histories_table.php.stub';
 
         include_once __DIR__ . '/database/migrations/create_sales_orders_table.php';
+        include_once __DIR__ . '/database/migrations/create_sales_managers_table.php';
 
         (new CreateStateHistoriesTable())->up();
         (new CreateSalesOrdersTable())->up();
+        (new CreateSalesManagersTable())->up();
     }
 }

--- a/tests/TestModels/SalesManager.php
+++ b/tests/TestModels/SalesManager.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Asantibanez\LaravelEloquentStateMachines\Tests\TestModels;
+
+use Illuminate\Auth\Authenticatable;
+use Illuminate\Contracts\Auth\Authenticatable as AuthenticatableAlias;
+use Illuminate\Database\Eloquent\Model;
+
+class SalesManager extends Model implements AuthenticatableAlias
+{
+    use Authenticatable;
+
+    protected $guarded = [];
+}

--- a/tests/database/factories/SalesManagerFactory.php
+++ b/tests/database/factories/SalesManagerFactory.php
@@ -1,0 +1,11 @@
+<?php
+
+use Asantibanez\LaravelEloquentStateMachines\Tests\TestModels\SalesManager;
+use Faker\Generator as Faker;
+
+$factory->define(SalesManager::class, function (Faker $faker) {
+    return [
+        'name' => $faker->name,
+        'email' => $faker->email,
+    ];
+});

--- a/tests/database/migrations/create_sales_managers_table.php
+++ b/tests/database/migrations/create_sales_managers_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateSalesManagersTable extends Migration
+{
+    public function up()
+    {
+        Schema::create('sales_managers', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('email');
+            $table->timestamps();
+        });
+    }
+
+    public function down()
+    {
+        Schema::dropIfExists('sales_managers');
+    }
+}


### PR DESCRIPTION
## Summary

This PRs adds support to registering a `responsible` for each state transition made and registered in `StateHistory`. `responsible` can be manually assigned or automatically detected.

To manually assign a responsible, you can specify a 3rd parameter to the `transitionTo` method named `$responsible`. This parameter should be an object of any time, most commonly `User` which will be associated with the transition.

```php
$salesOrder->status()->transitionTo('approved', $customProperties, $responsible = $salesManager);
```

If no responsible is specified, `auth()->user()` will be used if available.

```php
$salesOrder->status()->transitionTo('approved'); // $responsible = auth()->user()
```

If no responsible specified and can't be automatically detected, then `responsible` will be `null`.

### Querying Responsible

You can use the state machine method `responsible()` to get a hold of the responsible object for the transition for the current state.

```php
$responsible = $salesOrder->status()->responsible();
```

Since `responsible` is a polymorphic relationship, it can get any model you specify.

If you want to get the responsible of a previous transition, you can use the `snapshotWhen($state)` method and query the responsible using the `responsible` attribute.

```php
$responsible = $salesOrder->status()->snapshotWhen('approved')->responsible;
```

## Type of Change

- [x] :rocket: New Feature