### PR TITLE
Adds check for current state when transitioning to same state

### DIFF
--- a/src/StateMachines/StateMachine.php
+++ b/src/StateMachines/StateMachine.php
@@ -23,6 +23,13 @@ abstract class StateMachine
         $this->model = $model;
     }
 
+    public function currentState()
+    {
+        $field = $this->field;
+
+        return $this->model->$field;
+    }
+
     public function was($state)
     {
         return $this->model->stateHistory()
@@ -89,6 +96,10 @@ abstract class StateMachine
      */
     public function transitionTo($from, $to, $customProperties = [])
     {
+        if ($to === $this->currentState()) {
+            return;
+        }
+
         if (!$this->canBe($from, $to)) {
             throw new TransitionNotAllowedException();
         }

--- a/tests/Feature/HasStateMachinesTest.php
+++ b/tests/Feature/HasStateMachinesTest.php
@@ -76,6 +76,27 @@ class HasStateMachinesTest extends TestCase
     }
 
     /** @test */
+    public function should_not_do_anything_when_transitioning_to_same_state()
+    {
+        //Arrange
+        $salesOrder = factory(SalesOrder::class)->create();
+
+        $this->assertTrue($salesOrder->status()->is('pending'));
+
+        $this->assertEquals(1, $salesOrder->status()->history()->count());
+
+        //Act
+        $salesOrder->status()->transitionTo('pending');
+
+        //Assert
+        $salesOrder->refresh();
+
+        $this->assertTrue($salesOrder->status()->is('pending'));
+
+        $this->assertEquals(1, $salesOrder->status()->history()->count());
+    }
+
+    /** @test */
     public function can_check_next_possible_transitions()
     {
         //Arrange


### PR DESCRIPTION
## Summary

This PR adds check for "model's current" state vs "transition to" state. If state is the same, the transition is discarded and nothing happens.

## Type of Change

- [x] :rocket: New Feature