### PR TITLE
Update PHP requirements, add ^8.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.2|^7.3|^7.4",
+        "php": "^7.2|^7.3|^7.4|^8.0",
         "illuminate/support": "^6.0|^7.0|^8.0",
         "javoscript/laravel-macroable-models": "^1.0"
     },


### PR DESCRIPTION
## Summary

Laravel 8.0 supports php 8.0.
This modification will allow installation  support.

## Type of Change

- [ ] :rocket: New Feature
- [x] :bug: Bug Fix
- [ ] :hammer: Refactor
- [ ] :question: [Other]
