### PR TITLE
Add before transition hooks and refactored after transition hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to `laravel-eloquent-state-machines` will be documented in this file
 
+## v3.0.0 - 2021-02-10
+
+- Added `beforeTransitionHooks`
+- **Breaking Change**: Renamed `transitionHooks` to `afterTransitionHooks` and changed arguments for callbacks
+- Refactored tests
+
 ## v2.3.0 - 2020-01-26
 
 - Added support for PHP 8.

--- a/README.md
+++ b/README.md
@@ -377,24 +377,43 @@ applying the transition.
 
 ### Adding Hooks 
 
-We can also add custom hooks/callbacks that will be executed once a transition is applied. 
-To do so, we must override the `transitionHooks()` method in our state machine.
+We can also add custom hooks/callbacks that will be executed before/after a transition is applied. 
+To do so, we must override the `beforeTransitionHooks()` and `afterTransitionHooks()` methods in our state machine 
+accordingly.
 
-The `transitionHooks()` method must return an keyed array with the state and an array of callbacks/closures
-to be executed. Eg. 
+Both transition hooks methods must return a keyed array with the state and an array of callbacks/closures
+to be executed.
+
+> NOTE: The keys for the array must be the `$from` states.
+
+Example 
 
 ```php
 class StatusStateMachine extends StateMachine
 {
-    public function transitionHooks(): array
+    public function beforeTransitionHooks(): array
     {
         return [
-            'processed' => [
-                function ($from, $model) {
-                    // Dispatch some job
+            'approved' => [
+                function ($to, $model) {
+                    // Dispatch some job BEFORE "approved changes to $to"
                 },
-                function ($from, $model) {
-                    // Send mail
+                function ($to, $model) {
+                    // Send mail BEFORE "approved changes to $to" 
+                },
+            ],
+        ];
+    }
+    
+    public function afterTransitionHooks(): array
+    {
+        return [
+            'approved' => [
+                function ($to, $model) {
+                    // Dispatch some job AFTER "approved changes to $to"
+                },
+                function ($to, $model) {
+                    // Send mail AFTER "approved changes to $to" 
                 },
             ],
         ];

--- a/src/StateMachines/StateMachine.php
+++ b/src/StateMachines/StateMachine.php
@@ -124,11 +124,11 @@ abstract class StateMachine
             $this->model->recordState($field, $from, $to, $customProperties, $responsible);
         }
 
-        $transitionHooks = $this->transitionHooks()[$to] ?? [];
+        $afterTransitionHooks = $this->afterTransitionHooks()[$from] ?? [];
 
-        collect($transitionHooks)
-            ->each(function ($callable) use ($from) {
-                $callable($from, $this->model);
+        collect($afterTransitionHooks)
+            ->each(function ($callable) use ($to) {
+                $callable($to, $this->model);
             });
 
         $this->cancelAllPendingTransitions();
@@ -181,7 +181,7 @@ abstract class StateMachine
         return null;
     }
 
-    public function transitionHooks() : array
+    public function afterTransitionHooks() : array
     {
         return [];
     }

--- a/src/StateMachines/StateMachine.php
+++ b/src/StateMachines/StateMachine.php
@@ -107,6 +107,13 @@ abstract class StateMachine
             throw new ValidationException($validator);
         }
 
+        $beforeTransitionHooks = $this->beforeTransitionHooks()[$from] ?? [];
+
+        collect($beforeTransitionHooks)
+            ->each(function ($callable) use ($to) {
+                $callable($to, $this->model);
+            });
+
         $field = $this->field;
         $this->model->$field = $to;
         $this->model->save();
@@ -174,7 +181,12 @@ abstract class StateMachine
         return null;
     }
 
-    public function transitionHooks() : array {
+    public function transitionHooks() : array
+    {
+        return [];
+    }
+
+    public function beforeTransitionHooks() : array {
         return [];
     }
 }

--- a/tests/Feature/BeforeTransitionHookTest.php
+++ b/tests/Feature/BeforeTransitionHookTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Asantibanez\LaravelEloquentStateMachines\Tests\Feature;
+
+use Asantibanez\LaravelEloquentStateMachines\Tests\TestCase;
+use Asantibanez\LaravelEloquentStateMachines\Tests\TestModels\SalesOrderWithBeforeTransitionHook;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+
+class BeforeTransitionHookTest extends TestCase
+{
+    use RefreshDatabase;
+    use WithFaker;
+
+    /** @test */
+    public function should_call_before_transition_hooks()
+    {
+        //Arrange
+        $salesOrder = SalesOrderWithBeforeTransitionHook::create();
+
+        $this->assertNull($salesOrder->total);
+        $this->assertNull($salesOrder->notes);
+
+        //Act
+        $salesOrder->status()->transitionTo('approved');
+
+        //Assert
+        $salesOrder->refresh();
+
+        $this->assertEquals(100, $salesOrder->total);
+        $this->assertEquals('Notes updated', $salesOrder->notes);
+    }
+
+    /** @test */
+    public function should_not_call_before_transition_hooks_if_not_defined()
+    {
+        //Arrange
+        $salesOrder = SalesOrderWithBeforeTransitionHook::create([
+            'status' => 'approved'
+        ]);
+
+        $this->assertNull($salesOrder->total);
+        $this->assertNull($salesOrder->notes);
+
+        //Act
+        $salesOrder->status()->transitionTo('processed');
+
+        //Assert
+        $salesOrder->refresh();
+
+        $this->assertNull($salesOrder->total);
+        $this->assertNull($salesOrder->notes);
+    }
+}

--- a/tests/Feature/HasStateMachinesTest.php
+++ b/tests/Feature/HasStateMachinesTest.php
@@ -300,26 +300,6 @@ class HasStateMachinesTest extends TestCase
     }
 
     /** @test */
-    public function should_call_transition_hook()
-    {
-        Queue::fake();
-
-        //Arrange
-        $salesOrder = factory(SalesOrder::class)->create([
-            'status' => 'approved',
-        ]);
-
-        //Act
-        $salesOrder->fulfillment()->transitionTo('pending');
-
-        //Assert
-        Queue::assertPushed(StartSalesOrderFulfillmentJob::class, function ($job) use ($salesOrder) {
-            $this->assertEquals($salesOrder->id, $job->salesOrder->id);
-            return true;
-        });
-    }
-
-    /** @test */
     public function can_check_if_previous_state_was_transitioned()
     {
         //Arrange

--- a/tests/TestJobs/AfterTransitionJob.php
+++ b/tests/TestJobs/AfterTransitionJob.php
@@ -1,0 +1,15 @@
+<?php
+
+
+namespace Asantibanez\LaravelEloquentStateMachines\Tests\TestJobs;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+
+class AfterTransitionJob implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+}

--- a/tests/TestJobs/BeforeTransitionJob.php
+++ b/tests/TestJobs/BeforeTransitionJob.php
@@ -1,0 +1,15 @@
+<?php
+
+
+namespace Asantibanez\LaravelEloquentStateMachines\Tests\TestJobs;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+
+class BeforeTransitionJob implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+}

--- a/tests/TestModels/SalesOrderWithAfterTransitionHook.php
+++ b/tests/TestModels/SalesOrderWithAfterTransitionHook.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Asantibanez\LaravelEloquentStateMachines\Tests\TestModels;
+
+use Asantibanez\LaravelEloquentStateMachines\Tests\TestStateMachines\SalesOrders\StatusWithAfterTransitionHookStateMachine;
+use Asantibanez\LaravelEloquentStateMachines\Traits\HasStateMachines;
+use Illuminate\Database\Eloquent\Model;
+
+class SalesOrderWithAfterTransitionHook extends Model
+{
+    use HasStateMachines;
+
+    protected $table = 'sales_orders';
+
+    protected $guarded = [];
+
+    public $stateMachines = [
+        'status' => StatusWithAfterTransitionHookStateMachine::class,
+    ];
+}

--- a/tests/TestModels/SalesOrderWithBeforeTransitionHook.php
+++ b/tests/TestModels/SalesOrderWithBeforeTransitionHook.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Asantibanez\LaravelEloquentStateMachines\Tests\TestModels;
+
+use Asantibanez\LaravelEloquentStateMachines\Tests\TestStateMachines\SalesOrders\StatusWithBeforeTransitionHookStateMachine;
+use Asantibanez\LaravelEloquentStateMachines\Traits\HasStateMachines;
+use Illuminate\Database\Eloquent\Model;
+
+class SalesOrderWithBeforeTransitionHook extends Model
+{
+    use HasStateMachines;
+
+    protected $table = 'sales_orders';
+
+    protected $guarded = [];
+
+    public $stateMachines = [
+        'status' => StatusWithBeforeTransitionHookStateMachine::class,
+    ];
+}

--- a/tests/TestStateMachines/SalesOrders/FulfillmentStateMachine.php
+++ b/tests/TestStateMachines/SalesOrders/FulfillmentStateMachine.php
@@ -44,7 +44,7 @@ class FulfillmentStateMachine extends StateMachine
         return parent::validatorForTransition($from, $to, $model);
     }
 
-    public function transitionHooks(): array
+    public function afterTransitionHooks(): array
     {
         return [
             'pending' => [

--- a/tests/TestStateMachines/SalesOrders/StatusWithAfterTransitionHookStateMachine.php
+++ b/tests/TestStateMachines/SalesOrders/StatusWithAfterTransitionHookStateMachine.php
@@ -5,9 +5,9 @@ namespace Asantibanez\LaravelEloquentStateMachines\Tests\TestStateMachines\Sales
 
 
 use Asantibanez\LaravelEloquentStateMachines\StateMachines\StateMachine;
-use Asantibanez\LaravelEloquentStateMachines\Tests\TestJobs\BeforeTransitionJob;
+use Asantibanez\LaravelEloquentStateMachines\Tests\TestJobs\AfterTransitionJob;
 
-class StatusWithBeforeTransitionHookStateMachine extends StateMachine
+class StatusWithAfterTransitionHookStateMachine extends StateMachine
 {
     public function recordHistory(): bool
     {
@@ -27,19 +27,21 @@ class StatusWithBeforeTransitionHookStateMachine extends StateMachine
         return 'pending';
     }
 
-    public function beforeTransitionHooks(): array
+    public function transitionHooks(): array
     {
         return [
-            'pending' => [
-                function($to, $model) {
-                    $model->total = 100;
+            'approved' => [
+                function($from, $model) {
+                    $model->total = 200;
+                    $model->save();
                 },
-                function($to, $model) {
-                    $model->notes = 'Notes updated';
+                function($from, $model) {
+                    $model->notes = 'after';
+                    $model->save();
                 },
-                function ($to, $model) {
-                    BeforeTransitionJob::dispatch();
-                }
+                function ($from, $model) {
+                    AfterTransitionJob::dispatch();
+                },
             ]
         ];
     }

--- a/tests/TestStateMachines/SalesOrders/StatusWithAfterTransitionHookStateMachine.php
+++ b/tests/TestStateMachines/SalesOrders/StatusWithAfterTransitionHookStateMachine.php
@@ -27,19 +27,19 @@ class StatusWithAfterTransitionHookStateMachine extends StateMachine
         return 'pending';
     }
 
-    public function transitionHooks(): array
+    public function afterTransitionHooks(): array
     {
         return [
-            'approved' => [
-                function($from, $model) {
+            'pending' => [
+                function($to, $model) {
                     $model->total = 200;
                     $model->save();
                 },
-                function($from, $model) {
+                function($to, $model) {
                     $model->notes = 'after';
                     $model->save();
                 },
-                function ($from, $model) {
+                function ($to, $model) {
                     AfterTransitionJob::dispatch();
                 },
             ]

--- a/tests/TestStateMachines/SalesOrders/StatusWithBeforeTransitionHookStateMachine.php
+++ b/tests/TestStateMachines/SalesOrders/StatusWithBeforeTransitionHookStateMachine.php
@@ -1,0 +1,42 @@
+<?php
+
+
+namespace Asantibanez\LaravelEloquentStateMachines\Tests\TestStateMachines\SalesOrders;
+
+
+use Asantibanez\LaravelEloquentStateMachines\StateMachines\StateMachine;
+
+class StatusWithBeforeTransitionHookStateMachine extends StateMachine
+{
+    public function recordHistory(): bool
+    {
+        return true;
+    }
+
+    public function transitions(): array
+    {
+        return [
+            'pending' => ['approved'],
+            'approved' => ['processed'],
+        ];
+    }
+
+    public function defaultState(): ?string
+    {
+        return 'pending';
+    }
+
+    public function beforeTransitionHooks(): array
+    {
+        return [
+            'pending' => [
+                function($to, $model) {
+                    $model->total = 100;
+                },
+                function($to, $model) {
+                    $model->notes = 'Notes updated';
+                }
+            ]
+        ];
+    }
+}

--- a/tests/database/migrations/create_sales_orders_table.php
+++ b/tests/database/migrations/create_sales_orders_table.php
@@ -10,6 +10,8 @@ class CreateSalesOrdersTable extends Migration
     {
         Schema::create('sales_orders', function (Blueprint $table) {
             $table->id();
+            $table->string('notes')->nullable();
+            $table->decimal('total')->nullable();
             $table->string('status');
             $table->string('fulfillment')->nullable();
             $table->timestamps();


### PR DESCRIPTION
## Summary

This PR adds support for "before hooks" to be ran before the state transition is applied to the model. This allows to encapsulate even more all the transition behavior in the State Machine class.

Since `beforeTransitionHooks` was added, `transitionHooks` was renamed to `afterTransitionHooks`, creating a **breaking change** in the implementation. Also, `afterTransitionHooks` are now defined similar to `beforeTransitionHooks` where the array is keyed with the `$from` state value instead of `$to` state value. This means current `afterTransitionHooks` will not be fired since the callback arguments have changed.

Tests were extracted and refactored for readability and extensibility.

## Issue

N/A

## Type of Change

- [x] :rocket: New Feature
- [x] :hammer: Refactor

## Screenshot/Video

N/A
