### PR TITLE
FEATURE: Changed key for afterTransitionHooks callbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -404,10 +404,11 @@ We can also add custom hooks/callbacks that will be executed before/after a tran
 To do so, we must override the `beforeTransitionHooks()` and `afterTransitionHooks()` methods in our state machine 
 accordingly.
 
-Both transition hooks methods must return a keyed array with the state and an array of callbacks/closures
+Both transition hooks methods must return a keyed array with the state as key, and an array of callbacks/closures
 to be executed.
 
-> NOTE: The keys for the array must be the `$from` states.
+> NOTE: The keys for beforeTransitionHooks() must be the `$from` states.
+> NOTE: The keys for afterTransitionHooks() must be the `$to` states.
 
 Example 
 
@@ -431,12 +432,12 @@ class StatusStateMachine extends StateMachine
     public function afterTransitionHooks(): array
     {
         return [
-            'approved' => [
-                function ($to, $model) {
-                    // Dispatch some job AFTER "approved changes to $to"
+            'processed' => [
+                function ($from, $model) {
+                    // Dispatch some job AFTER "$from transitioned to processed"
                 },
-                function ($to, $model) {
-                    // Send mail AFTER "approved changes to $to" 
+                function ($from, $model) {
+                    // Send mail AFTER "$from transitioned to processed" 
                 },
             ],
         ];

--- a/src/StateMachines/StateMachine.php
+++ b/src/StateMachines/StateMachine.php
@@ -129,11 +129,11 @@ abstract class StateMachine
             $this->model->recordState($field, $from, $to, $customProperties, $responsible, $changedAttributes);
         }
 
-        $afterTransitionHooks = $this->afterTransitionHooks()[$from] ?? [];
+        $afterTransitionHooks = $this->afterTransitionHooks()[$to] ?? [];
 
         collect($afterTransitionHooks)
-            ->each(function ($callable) use ($to) {
-                $callable($to, $this->model);
+            ->each(function ($callable) use ($from) {
+                $callable($from, $this->model);
             });
 
         $this->cancelAllPendingTransitions();

--- a/tests/TestStateMachines/SalesOrders/StatusWithAfterTransitionHookStateMachine.php
+++ b/tests/TestStateMachines/SalesOrders/StatusWithAfterTransitionHookStateMachine.php
@@ -30,16 +30,16 @@ class StatusWithAfterTransitionHookStateMachine extends StateMachine
     public function afterTransitionHooks(): array
     {
         return [
-            'pending' => [
-                function($to, $model) {
+            'approved' => [
+                function($from, $model) {
                     $model->total = 200;
                     $model->save();
                 },
-                function($to, $model) {
+                function($from, $model) {
                     $model->notes = 'after';
                     $model->save();
                 },
-                function ($to, $model) {
+                function ($from, $model) {
                     AfterTransitionJob::dispatch();
                 },
             ]


### PR DESCRIPTION
## Summary

This PR reverts `afterTransitionHooks` array keys to use the `$to` state instead of the `$from` state for its definition. Callbacks are now expected to be keyed for the state the model is now and not from where it transitioned from.

## Issue

Resolves #17 

## Type of Change

- [x] :rocket: New Feature

## Screenshot/Video

![image](https://user-images.githubusercontent.com/5126648/111920567-b64ca500-8a5d-11eb-9f6c-50c8161b465d.png)

