### PR TITLE
Added support for arrays in transition query methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,6 +293,8 @@ The `whereHas{FIELD_NAME}` method accepts a closure where you can add the follow
 - `withResponsible($responsible|$id)`
 - `withCustomProperty($property, $operator, $value)`
 
+The `$from` and `$to` parameters can be either a status name as a string or an array of status names.
+
 ```php
 SalesOrder::with()
     ->whereHasStatus(function ($query) {

--- a/src/Models/StateHistory.php
+++ b/src/Models/StateHistory.php
@@ -64,7 +64,11 @@ class StateHistory extends Model
 
     public function scopeFrom($query, $from)
     {
-        $query->where('from', $from);
+        if (is_array($from)) {
+            $query->whereIn('from', $from);
+        } else {
+            $query->where('from', $from);
+        }
     }
 
     public function scopeTransitionedFrom($query, $from)
@@ -74,7 +78,11 @@ class StateHistory extends Model
 
     public function scopeTo($query, $to)
     {
-        $query->where('to', $to);
+        if (is_array($to)) {
+            $query->whereIn('to', $to);
+        } else {
+            $query->where('to', $to);
+        }
     }
 
     public function scopeTransitionedTo($query, $to)

--- a/tests/TestStateMachines/SalesOrders/StatusStateMachine.php
+++ b/tests/TestStateMachines/SalesOrders/StatusStateMachine.php
@@ -16,8 +16,9 @@ class StatusStateMachine extends StateMachine
     public function transitions(): array
     {
         return [
-            'pending' => ['approved'],
+            'pending' => ['approved', 'waiting'],
             'approved' => ['processed'],
+            'waiting' => ['cancelled'],
         ];
     }
 


### PR DESCRIPTION
## Summary

Added support for using an array of statuses when using transitionedFrom(), transitionedTo() and withTransition() methods.

## Type of Change

- [x] :rocket: New Feature
- [ ] :bug: Bug Fix
- [ ] :hammer: Refactor
- [ ] :question: [Other]
