### PR TITLE
Added ability to use wildcard in allowed state changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Laravel Eloquent State Machines also allow you to automatically record history o
 may have and query this history to take specific actions accordingly.
 
 At its core, this package has been created to provide a simple but powerful API so Laravel developers
-feel right at home. 
+feel right at home.
 
 **Examples**
 
@@ -27,7 +27,7 @@ $salesOrder->fulfillment; // null, 'pending', 'completed'
 ```
 
 Transitioning from one state to another
-  
+
 ```php
 $salesOrder->status()->transitionTo('approved');
 
@@ -43,7 +43,7 @@ $salesOrder->status()->transitionTo('approved', [], $responsible); // auth()->us
 ```
 
 Checking available transitions
-  
+
 ```php
 $salesOrder->status()->canBe('approved');
 
@@ -51,15 +51,15 @@ $salesOrder->status()->canBe('declined');
 ```
 
 Checking current state
-  
+
 ```php
 $salesOrder->status()->is('approved');
 
-$salesOrder->status()->responsible(); // User|null 
+$salesOrder->status()->responsible(); // User|null
 ```
 
 Checking transitions history
-  
+
 ```php
 $salesOrder->status()->was('approved');
 
@@ -95,7 +95,7 @@ php artisan vendor:publish --provider="Asantibanez\LaravelEloquentStateMachines\
 
 ## Usage
 
-### Defining our StateMachine 
+### Defining our StateMachine
 
 Imagine we have a `SalesOrder` model which has a `status` field for tracking the different stages
 our sales order can be in the system: `REGISTERED`, `APPROVED`, `PROCESSED` or `DECLINED`.
@@ -109,7 +109,7 @@ For example, we can create a `StatusStateMachine` for our SalesOrder model
 php artisan make:state-machine StatusStateMachine
 ```
 
-After running the command, we will have a new StateMachine class created 
+After running the command, we will have a new StateMachine class created
 in the `App\StateMachines` directory. The class will have the following code.
 
 ```php
@@ -148,63 +148,76 @@ public function transitions(): array
 }
 ```
 
+Wildcards are allowed to allow any state change
+
+```php
+public function transitions(): array
+{
+    return [
+        '*' => ['approved', 'declined'], // From any to 'approved' or 'declined'
+        'approved' => '*', // From 'approved' to any
+        '*' => '*', // From any to any
+    ];
+}
+```
+
 We can define the default/starting state too
 
 ```php
 public function defaultState(): ?string
 {
-    return 'pending'; // it can be null too 
+    return 'pending'; // it can be null too
 }
 ```
 
-The StateMachine class allows recording each one of the transitions automatically for you. To 
+The StateMachine class allows recording each one of the transitions automatically for you. To
 enable this behavior, we must set `recordHistory()` to return `true`;
 
 ```php
 public function recordHistory(): bool
 {
-    return true; 
+    return true;
 }
 ```
 
 ### Registering our StateMachine
 
 Once we have defined our StateMachine, we can register it in our `SalesOrder` model, in a `$stateMachine`
-attribute. Here, we set the bound model `field` and state machine class that will control it.  
+attribute. Here, we set the bound model `field` and state machine class that will control it.
 
 ```php
 use Asantibanez\LaravelEloquentStateMachines\Traits\HasStateMachines;
 use App\StateMachines\StatusStateMachine;
 
-class SalesOrder extends Model 
+class SalesOrder extends Model
 {
     Use HasStateMachines;
 
     public $stateMachines = [
         'status' => StatusStateMachine::class
-    ];   
+    ];
 }
 ```
 
-### State Machine Methods  
+### State Machine Methods
 
 When registering `$stateMachines` in our model, each state field will have it's own custom method to
 interact with the state machine and transitioning methods. The `HasStateMachines` trait defines
-one method per each field mapped in `$stateMachines`. Eg. 
+one method per each field mapped in `$stateMachines`. Eg.
 
 For
-```php 
+```php
 'status' => StatusStateMachine::class,
 'fulfillment_status' => FulfillmentStatusStateMachine::class
 ```
 
-We will have an accompanying method 
+We will have an accompanying method
 ```php
 status();
 fulfillment_status(); // or fulfillmentStatus()
 ```
 
-with which we can use to check our current state, history and apply transitions. 
+with which we can use to check our current state, history and apply transitions.
 
 > Note: the field "status" will be kept intact and in sync with the state machine
 
@@ -221,16 +234,16 @@ You can also pass in `$customProperties` if needed
 $salesOrder->status()->transitionTo($to = 'approved', $customProperties = [
     'comments' => 'All ready to go'
 ]);
-``` 
+```
 
 A `$responsible` can be also specified. By default, `auth()->user()` will be used
 ```php
 $salesOrder->status()->transitionTo(
-    $to = 'approved', 
-    $customProperties = [], 
+    $to = 'approved',
+    $customProperties = [],
     $responsible = User::first()
 );
-``` 
+```
 
 When applying the transition, the state machine will verify if the state transition is allowed according
 to the `transitions()` states we've defined. If the transition is not allowed, a `TransitionNotAllowed`
@@ -247,14 +260,14 @@ With `recordHistory()` turned on, we can query the history of states our field h
 ```php
 $salesOrder->status()->was('approved'); // true or false
 
-$salesOrder->status()->timesWas('approved'); // int 
+$salesOrder->status()->timesWas('approved'); // int
 
 $salesOrder->status()->whenWas('approved'); // ?Carbon
-``` 
+```
 
 As seen above, we can check whether or not our field has transitioned to one of the queried states.
 
-We can also get the latest snapshot or all snapshots for a given state   
+We can also get the latest snapshot or all snapshots for a given state
 
 ```php
 $salesOrder->status()->snapshotWhen('approved');
@@ -262,11 +275,11 @@ $salesOrder->status()->snapshotWhen('approved');
 $salesOrder->status()->snapshotsWhen('approved');
 ```
 
-The full history of transitioned states is also available 
+The full history of transitioned states is also available
 
 ```php
 $salesOrder->status()->history()->get();
-``` 
+```
 
 The `history()` method returns an Eloquent relationship that can be chained with the following
 scopes to further down the results.
@@ -277,12 +290,12 @@ $salesOrder->status()->history()
     ->to('approved')
     ->withCustomProperty('comments', 'like', '%good%')
     ->get();
-``` 
+```
 
 ### Using Query Builder
 
-The `HasStateMachines` trait introduces a helper method when querying your models based on the state history of each 
-state machine. You can use the `whereHas{FIELD_NAME}` (eg: `whereHasStatus`, `whereHasFulfillment`) to add constraints 
+The `HasStateMachines` trait introduces a helper method when querying your models based on the state history of each
+state machine. You can use the `whereHas{FIELD_NAME}` (eg: `whereHasStatus`, `whereHasFulfillment`) to add constraints
 to your model queries depending on state transitions, responsible and custom properties.
 
 The `whereHas{FIELD_NAME}` method accepts a closure where you can add the following type of constraints:
@@ -319,7 +332,7 @@ When applying transitions with custom properties, we can get our registered valu
 $salesOrder->status()->getCustomProperty('comments');
 ```
 
-This method will reach for the custom properties of the current state. You can get custom 
+This method will reach for the custom properties of the current state. You can get custom
 properties of previous states using the snapshotWhen($state) method.
 
 ```php
@@ -334,7 +347,7 @@ Similar to custom properties, you can retrieve the `$responsible` object that ap
 $salesOrder->status()->responsible();
 ```
 
-This method will reach for the responsible of the current state. You can get responsible of previous states 
+This method will reach for the responsible of the current state. You can get responsible of previous states
 using the snapshotWhen($state) method.
 
 ```php
@@ -342,7 +355,7 @@ $salesOrder->status()->snapshotWhen('approved')->responsible;
 ```
 
 >Note: `responsible` can be `null` if not specified and when the transition happens in a background job. This is
->because no `auth()->user()` is available. 
+>because no `auth()->user()` is available.
 
 ## Advanced Usage
 
@@ -389,19 +402,19 @@ class StatusStateMachine extends StateMachine
                 'total' => 'gt:0',
             ]);
         }
-        
+
         return parent:validatorForTransition($from, $to, $model);
     }
 }
 ```
 
 In the example above, we are validating that our Sales Order model total is greater than 0 before
-applying the transition. 
+applying the transition.
 
-### Adding Hooks 
+### Adding Hooks
 
-We can also add custom hooks/callbacks that will be executed before/after a transition is applied. 
-To do so, we must override the `beforeTransitionHooks()` and `afterTransitionHooks()` methods in our state machine 
+We can also add custom hooks/callbacks that will be executed before/after a transition is applied.
+To do so, we must override the `beforeTransitionHooks()` and `afterTransitionHooks()` methods in our state machine
 accordingly.
 
 Both transition hooks methods must return a keyed array with the state as key, and an array of callbacks/closures
@@ -410,7 +423,7 @@ to be executed.
 > NOTE: The keys for beforeTransitionHooks() must be the `$from` states.
 > NOTE: The keys for afterTransitionHooks() must be the `$to` states.
 
-Example 
+Example
 
 ```php
 class StatusStateMachine extends StateMachine
@@ -423,12 +436,12 @@ class StatusStateMachine extends StateMachine
                     // Dispatch some job BEFORE "approved changes to $to"
                 },
                 function ($to, $model) {
-                    // Send mail BEFORE "approved changes to $to" 
+                    // Send mail BEFORE "approved changes to $to"
                 },
             ],
         ];
     }
-    
+
     public function afterTransitionHooks(): array
     {
         return [
@@ -437,11 +450,11 @@ class StatusStateMachine extends StateMachine
                     // Dispatch some job AFTER "$from transitioned to processed"
                 },
                 function ($from, $model) {
-                    // Send mail AFTER "$from transitioned to processed" 
+                    // Send mail AFTER "$from transitioned to processed"
                 },
             ],
         ];
-    } 
+    }
 }
 ```
 
@@ -449,13 +462,13 @@ class StatusStateMachine extends StateMachine
 
 You can also postpone transitions to other states by using the `postponeTransitionTo` method.
 This method accepts the same parameters as `transitionTo` plus a `$when` Carbon instance to specify
-when the transition is to be run. 
- 
-`postponeTransitionTo` doesn't apply the transition immediately. Instead, it saves it 
-into a `pending_transitions` table where it keeps track of all pending transitions for all
-models. 
+when the transition is to be run.
 
-To enable running this transitions at a later time, you must schedule the 
+`postponeTransitionTo` doesn't apply the transition immediately. Instead, it saves it
+into a `pending_transitions` table where it keeps track of all pending transitions for all
+models.
+
+To enable running this transitions at a later time, you must schedule the
 `PendingTransitionsDispatcher` job class into your scheduler to run every one, five or ten minutes.
 
 ```php
@@ -465,7 +478,7 @@ $schedule->job(PendingTransitionsDispatcher::class)->everyMinute();
 `PendingTransitionsDispatcher` is responsible for applying the postponed transitions at the specified
 `$when` date/time.
 
-You can check if a model has pending transitions for a particular state machine using the 
+You can check if a model has pending transitions for a particular state machine using the
 `hasPendingTransitions()` method
 
 ```php

--- a/src/StateMachines/StateMachine.php
+++ b/src/StateMachines/StateMachine.php
@@ -100,7 +100,7 @@ abstract class StateMachine
             return;
         }
 
-        if (!$this->canBe($from, $to)) {
+        if (!$this->canBe($from, $to) && !$this->canBe($from, '*') && !$this->canBe('*', $to) && !$this->canBe('*', '*')) {
             throw new TransitionNotAllowedException();
         }
 

--- a/tests/Feature/AnyTransitionTest.php
+++ b/tests/Feature/AnyTransitionTest.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Asantibanez\LaravelEloquentStateMachines\Tests\Feature;
+
+use Asantibanez\LaravelEloquentStateMachines\Tests\TestCase;
+use Asantibanez\LaravelEloquentStateMachines\Tests\TestModels\SalesOrderWithAnyToAny;
+use Asantibanez\LaravelEloquentStateMachines\Tests\TestModels\SalesOrderWithFromAny;
+use Asantibanez\LaravelEloquentStateMachines\Tests\TestModels\SalesOrderWithToAny;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Queue;
+
+class AnyTransitionTest extends TestCase
+{
+    use RefreshDatabase;
+    use WithFaker;
+
+    /** @test */
+    public function can_transition_to_any_state()
+    {
+        //Arrange
+        $salesOrder = SalesOrderWithToAny::create();
+
+        $this->assertTrue($salesOrder->status()->is('pending'));
+
+        $this->assertEquals('pending', $salesOrder->status);
+
+        //Act
+        $salesOrder->status()->transitionTo('approved');
+
+        //Assert
+        $salesOrder->refresh();
+
+        $this->assertTrue($salesOrder->status()->is('approved'));
+
+        $this->assertEquals('approved', $salesOrder->status);
+    }
+
+    /** @test */
+    public function can_transition_from_any_state()
+    {
+        //Arrange
+        $salesOrder = SalesOrderWithFromAny::create();
+
+        $this->assertTrue($salesOrder->status()->is('pending'));
+
+        $this->assertEquals('pending', $salesOrder->status);
+
+        //Act
+        $salesOrder->status()->transitionTo('approved');
+
+        //Assert
+        $salesOrder->refresh();
+
+        $this->assertTrue($salesOrder->status()->is('approved'));
+
+        $this->assertEquals('approved', $salesOrder->status);
+    }
+
+    /** @test */
+    public function can_transition_from_any_to_any_state()
+    {
+        //Arrange
+        $salesOrder = SalesOrderWithAnyToAny::create();
+
+        $this->assertTrue($salesOrder->status()->is('new'));
+
+        $this->assertEquals('new', $salesOrder->status);
+
+        //Act
+        $salesOrder->status()->transitionTo('random');
+
+        //Assert
+        $salesOrder->refresh();
+
+        $this->assertTrue($salesOrder->status()->is('random'));
+
+        $this->assertEquals('random', $salesOrder->status);
+    }
+}

--- a/tests/TestModels/SalesOrderWithAnyToAny.php
+++ b/tests/TestModels/SalesOrderWithAnyToAny.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Asantibanez\LaravelEloquentStateMachines\Tests\TestModels;
+
+use Asantibanez\LaravelEloquentStateMachines\Tests\TestStateMachines\SalesOrders\StatusAnyToAnyStateMachine;
+use Asantibanez\LaravelEloquentStateMachines\Traits\HasStateMachines;
+use Illuminate\Database\Eloquent\Model;
+
+class SalesOrderWithAnyToAny extends Model
+{
+    use HasStateMachines;
+
+    protected $table = 'sales_orders';
+
+    protected $guarded = [];
+
+    public $stateMachines = [
+        'status' => StatusAnyToAnyStateMachine::class,
+    ];
+}

--- a/tests/TestModels/SalesOrderWithFromAny.php
+++ b/tests/TestModels/SalesOrderWithFromAny.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Asantibanez\LaravelEloquentStateMachines\Tests\TestModels;
+
+use Asantibanez\LaravelEloquentStateMachines\Tests\TestStateMachines\SalesOrders\StatusFromAnyStateMachine;
+use Asantibanez\LaravelEloquentStateMachines\Traits\HasStateMachines;
+use Illuminate\Database\Eloquent\Model;
+
+class SalesOrderWithFromAny extends Model
+{
+    use HasStateMachines;
+
+    protected $table = 'sales_orders';
+
+    protected $guarded = [];
+
+    public $stateMachines = [
+        'status' => StatusFromAnyStateMachine::class,
+    ];
+}

--- a/tests/TestModels/SalesOrderWithToAny.php
+++ b/tests/TestModels/SalesOrderWithToAny.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Asantibanez\LaravelEloquentStateMachines\Tests\TestModels;
+
+use Asantibanez\LaravelEloquentStateMachines\Tests\TestStateMachines\SalesOrders\StatusToAnyStateMachine;
+use Asantibanez\LaravelEloquentStateMachines\Traits\HasStateMachines;
+use Illuminate\Database\Eloquent\Model;
+
+class SalesOrderWithToAny extends Model
+{
+    use HasStateMachines;
+
+    protected $table = 'sales_orders';
+
+    protected $guarded = [];
+
+    public $stateMachines = [
+        'status' => StatusToAnyStateMachine::class,
+    ];
+}

--- a/tests/TestStateMachines/SalesOrders/StatusAnyToAnyStateMachine.php
+++ b/tests/TestStateMachines/SalesOrders/StatusAnyToAnyStateMachine.php
@@ -1,0 +1,27 @@
+<?php
+
+
+namespace Asantibanez\LaravelEloquentStateMachines\Tests\TestStateMachines\SalesOrders;
+
+
+use Asantibanez\LaravelEloquentStateMachines\StateMachines\StateMachine;
+
+class StatusAnyToAnyStateMachine extends StateMachine
+{
+    public function recordHistory(): bool
+    {
+        return false;
+    }
+
+    public function transitions(): array
+    {
+        return [
+            '*' => '*',
+        ];
+    }
+
+    public function defaultState(): ?string
+    {
+        return 'new';
+    }
+}

--- a/tests/TestStateMachines/SalesOrders/StatusFromAnyStateMachine.php
+++ b/tests/TestStateMachines/SalesOrders/StatusFromAnyStateMachine.php
@@ -1,0 +1,27 @@
+<?php
+
+
+namespace Asantibanez\LaravelEloquentStateMachines\Tests\TestStateMachines\SalesOrders;
+
+
+use Asantibanez\LaravelEloquentStateMachines\StateMachines\StateMachine;
+
+class StatusFromAnyStateMachine extends StateMachine
+{
+    public function recordHistory(): bool
+    {
+        return false;
+    }
+
+    public function transitions(): array
+    {
+        return [
+            '*' => ['pending', 'approved', 'processed'],
+        ];
+    }
+
+    public function defaultState(): ?string
+    {
+        return 'pending';
+    }
+}

--- a/tests/TestStateMachines/SalesOrders/StatusToAnyStateMachine.php
+++ b/tests/TestStateMachines/SalesOrders/StatusToAnyStateMachine.php
@@ -1,0 +1,27 @@
+<?php
+
+
+namespace Asantibanez\LaravelEloquentStateMachines\Tests\TestStateMachines\SalesOrders;
+
+
+use Asantibanez\LaravelEloquentStateMachines\StateMachines\StateMachine;
+
+class StatusToAnyStateMachine extends StateMachine
+{
+    public function recordHistory(): bool
+    {
+        return false;
+    }
+
+    public function transitions(): array
+    {
+        return [
+            'pending' => '*',
+        ];
+    }
+
+    public function defaultState(): ?string
+    {
+        return 'pending';
+    }
+}


### PR DESCRIPTION
## Summary

This will add functionality that allows the user to use wildcards when defining state changes. This can prove useful if you have a lot of states and you dont want to type them all in when everything is allowed.
For example:

```php
// If it should be possible to change from any state to a given state:
return [
    '*' => [
        'approved'
    ],
];

// If it should be possible to change to any state from the 'pending' state:
return [
    'pending' => '*',
];

// If it should be possible to change to and from any state whatsoever:
return [
    '*' => '*',
];
```

## Type of Change

- [X] :rocket: New Feature
- [ ] :bug: Bug Fix
- [ ] :hammer: Refactor
- [ ] :question: [Other]
