### PR TITLE
Supply the transition hooks with more data

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ $salesOrder->status()->transitionTo('approved', [
 
 //With responsible
 $salesOrder->status()->transitionTo('approved', [], $responsible); // auth()->user() by default
+
+//With arbitrary hook data (only used in before and after hooks)
+$salesOrder->status()->transitionTo('approved', [], $responsible, ['referrer' => 'google']); // Can be of any type
 ```
 
 Checking available transitions
@@ -407,7 +410,7 @@ accordingly.
 Both transition hooks methods must return a keyed array with the state as key, and an array of callbacks/closures
 to be executed.
 
-> NOTE: The keys for beforeTransitionHooks() must be the `$from` states.
+> NOTE: The keys for beforeTransitionHooks() must be the `$from` states.  
 > NOTE: The keys for afterTransitionHooks() must be the `$to` states.
 
 Example 
@@ -443,6 +446,12 @@ class StatusStateMachine extends StateMachine
         ];
     } 
 }
+```
+
+The callback signature looks like this:
+
+```php
+function ($to | $from, $model, $customProperties = [], $responsible = null, $hookData = null);
 ```
 
 ### Postponing Transitions

--- a/src/Jobs/PendingTransitionExecutor.php
+++ b/src/Jobs/PendingTransitionExecutor.php
@@ -31,6 +31,7 @@ class PendingTransitionExecutor implements ShouldQueue
         $to = $this->pendingTransition->to;
         $customProperties = $this->pendingTransition->custom_properties;
         $responsible = $this->pendingTransition->responsible;
+        $hookData = $this->pendingTransition->hookData;
 
         if ($model->$field()->isNot($from)) {
             $exception = new InvalidStartingStateException(
@@ -42,6 +43,6 @@ class PendingTransitionExecutor implements ShouldQueue
             return;
         }
 
-        $model->$field()->transitionTo($to, $customProperties, $responsible);
+        $model->$field()->transitionTo($to, $customProperties, $responsible, $hookData);
     }
 }

--- a/src/StateMachines/State.php
+++ b/src/StateMachines/State.php
@@ -90,13 +90,14 @@ class State
         return $this->stateMachine->hasPendingTransitions();
     }
 
-    public function transitionTo($state, $customProperties = [], $responsible = null)
+    public function transitionTo($state, $customProperties = [], $responsible = null, $hookData = null)
     {
         $this->stateMachine->transitionTo(
             $from = $this->state,
             $to = $state,
             $customProperties,
-            $responsible
+            $responsible,
+            $hookData
         );
     }
 
@@ -105,17 +106,19 @@ class State
      * @param Carbon $when
      * @param array $customProperties
      * @param null $responsible
+     * @param null|mixed $hookData
      * @return null|PendingTransition
      * @throws TransitionNotAllowedException
      */
-    public function postponeTransitionTo($state, Carbon $when, $customProperties = [], $responsible = null) : ?PendingTransition
+    public function postponeTransitionTo($state, Carbon $when, $customProperties = [], $responsible = null, $hookData = null) : ?PendingTransition
     {
         return $this->stateMachine->postponeTransitionTo(
             $from = $this->state,
             $to = $state,
             $when,
             $customProperties,
-            $responsible
+            $responsible,
+            $hookData
         );
     }
 

--- a/src/StateMachines/StateMachine.php
+++ b/src/StateMachines/StateMachine.php
@@ -91,10 +91,11 @@ abstract class StateMachine
      * @param $to
      * @param array $customProperties
      * @param null|mixed $responsible
+     * @param null|mixed $hookData
      * @throws TransitionNotAllowedException
      * @throws ValidationException
      */
-    public function transitionTo($from, $to, $customProperties = [], $responsible = null)
+    public function transitionTo($from, $to, $customProperties = [], $responsible = null, $hookData = null)
     {
         if ($to === $this->currentState()) {
             return;
@@ -112,8 +113,8 @@ abstract class StateMachine
         $beforeTransitionHooks = $this->beforeTransitionHooks()[$from] ?? [];
 
         collect($beforeTransitionHooks)
-            ->each(function ($callable) use ($to) {
-                $callable($to, $this->model);
+            ->each(function ($callable) use ($to, $customProperties, $responsible, $hookData) {
+                $callable($to, $this->model, $customProperties, $responsible, $hookData);
             });
 
         $field = $this->field;
@@ -132,8 +133,8 @@ abstract class StateMachine
         $afterTransitionHooks = $this->afterTransitionHooks()[$to] ?? [];
 
         collect($afterTransitionHooks)
-            ->each(function ($callable) use ($from) {
-                $callable($from, $this->model);
+            ->each(function ($callable) use ($from, $customProperties, $responsible, $hookData) {
+                $callable($from, $this->model, $customProperties, $responsible, $hookData);
             });
 
         $this->cancelAllPendingTransitions();
@@ -145,10 +146,11 @@ abstract class StateMachine
      * @param Carbon $when
      * @param array $customProperties
      * @param null $responsible
+     * @param null|mixed $hookData
      * @return null|PendingTransition
      * @throws TransitionNotAllowedException
      */
-    public function postponeTransitionTo($from, $to, Carbon $when, $customProperties = [], $responsible = null) : ?PendingTransition
+    public function postponeTransitionTo($from, $to, Carbon $when, $customProperties = [], $responsible = null, $hookData = null) : ?PendingTransition
     {
         if ($to === $this->currentState()) {
             return null;
@@ -166,7 +168,8 @@ abstract class StateMachine
             $to,
             $when,
             $customProperties,
-            $responsible
+            $responsible,
+            $hookData
         );
     }
 

--- a/src/Traits/HasStateMachines.php
+++ b/src/Traits/HasStateMachines.php
@@ -133,7 +133,7 @@ trait HasStateMachines
         $this->stateHistory()->save($stateHistory);
     }
 
-    public function recordPendingTransition($field, $from, $to, $when, $customProperties = [], $responsible = null) : PendingTransition
+    public function recordPendingTransition($field, $from, $to, $when, $customProperties = [], $responsible = null, $hookData = null) : PendingTransition
     {
         /** @var PendingTransition $pendingTransition */
         $pendingTransition = PendingTransition::make([
@@ -141,7 +141,8 @@ trait HasStateMachines
             'from' => $from,
             'to' => $to,
             'transition_at' => $when,
-            'custom_properties' => $customProperties
+            'custom_properties' => $customProperties,
+            'hook_data' => $hookData,
         ]);
 
         if ($responsible !== null) {


### PR DESCRIPTION
## Summary

Currently it's very difficult to pass data to transition hooks. I have this problem when I want to make a transition and the hooks depend on data that was sent in the request. Currently I have to save the request data on the model, even though it's not necessary to save it in the database. This change will allow more data to be sent to transition hooks. 

## Type of Change

- [X] :rocket: New Feature
- [ ] :bug: Bug Fix
- [ ] :hammer: Refactor
- [ ] :question: [Other]
