### PR TITLE
Allow Laravel 9 and improve CI

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        php: [ '7.2', '7.3', '7.4', '8.0', '8.1' ]
+        php: [ '7.3', '7.4', '8.0', '8.1' ]
 
     steps:
       - name: Cancel Previous Run
@@ -27,7 +27,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install Composer dependencies
-        run: composer install --ignore-platform-reqs
+        run: composer install
 
       - name: Run tests
         run: ./vendor/bin/phpunit

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -6,16 +6,20 @@ jobs:
   phpunit:
     runs-on: ubuntu-latest
 
+    strategy:
+      matrix:
+        php: [ '7.2', '7.3', '7.4', '8.0', '8.1' ]
+
     steps:
       - name: Cancel Previous Run
         uses: styfle/cancel-workflow-action@0.6.0
         with:
           access_token: ${{ github.token }}
 
-      - name: Setup PHP
+      - name: Setup PHP ${{ matrix.php }}
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '7.4'
+          php-version: ${{ matrix.php }}
           extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, gd, exif, imagick, bcmath
           coverage: none
 

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.2|^7.3|^7.4|^8.0",
+        "php": "^7.3|^7.4|^8.0",
         "illuminate/support": "^6.0|^7.0|^8.0|^9.0",
         "javoscript/laravel-macroable-models": "^1.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -17,12 +17,12 @@
     ],
     "require": {
         "php": "^7.2|^7.3|^7.4|^8.0",
-        "illuminate/support": "^6.0|^7.0|^8.0",
+        "illuminate/support": "^6.0|^7.0|^8.0|^9.0",
         "javoscript/laravel-macroable-models": "^1.0"
     },
     "require-dev": {
         "laravel/legacy-factories": "^1.0.4",
-        "orchestra/testbench": "^4.0|^5.0|^6.0",
+        "orchestra/testbench": "^4.0|^5.0|^6.0|^7.0",
         "phpunit/phpunit": "^8.0|^9.0"
     },
     "autoload": {


### PR DESCRIPTION
## Summary

Here are the changes for issue #31.
In addition I took the liberty of improving CI by adding all supported versions of php.

## Issue

https://github.com/asantibanez/laravel-eloquent-state-machines/issues/31 

## Type of Change

- [ ] :rocket: New Feature
- [ ] :bug: Bug Fix
- [ ] :hammer: Refactor
- [x] :question: [Other]

