### PR TITLE
Several updates and typo fix in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,12 @@ Next, you must export the package migrations
 php artisan vendor:publish --provider="Asantibanez\LaravelEloquentStateMachines\LaravelEloquentStateMachinesServiceProvider" --tag="migrations"
 ```
 
+Finally, prepare required database tables
+
+```bash
+php artisan migrate
+```
+
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -384,6 +384,8 @@ This method must return a `Validator` that will be used to check the transition 
 the validator `fails()`, a `ValidationException` is thrown. Eg:
 
 ```php
+use Illuminate\Support\Facades\Validator as ValidatorFacade;
+
 class StatusStateMachine extends StateMachine
 {
     public function validatorForTransition($from, $to, $model): ?Validator
@@ -396,7 +398,7 @@ class StatusStateMachine extends StateMachine
             ]);
         }
         
-        return parent:validatorForTransition($from, $to, $model);
+        return parent::validatorForTransition($from, $to, $model);
     }
 }
 ```


### PR DESCRIPTION
Tiny updates in Readme. 

## Summary

- Added migration in installation steps.
- Added `use` statement to clarify  `ValidatorFacade` class.
- Fixed a typo. `parent:` was used to access parent method instead of `parent::`

## Type of Change

- [ ] :rocket: New Feature
- [ ] :bug: Bug Fix
- [ ] :hammer: Refactor
- [x] :question: Documentation update (Readme.md)