### PR TITLE
Fix typo in ReadMe

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ $salesOrder->status()->timesWas('approved');
 
 $salesOrder->status()->whenWas('approved');
 
-$salesOrder->fulfillment()->snapshowWhen('completed');
+$salesOrder->fulfillment()->snapshotWhen('completed');
 
 $salesOrder->status()->history()->get();
 ```


### PR DESCRIPTION
## Summary

Fixed `snapshotWhen` misspelt in the readme.

## Type of Change

- [ ] :rocket: New Feature
- [x] :bug: Bug Fix
- [ ] :hammer: Refactor
- [ ] :question: [Other]

